### PR TITLE
🔧 Updating the PR Template to remove the tasks items

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -8,11 +8,11 @@ Fixes # (issue)
 
 <!-- Please delete options that are not relevant. -->
 
-- [ ] feature: A new feature
-- [ ] fix: A bug fix
-- [ ] documentation: Documentation only changes
-- [ ] style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
-- [ ] refactor: A code change that neither fixes a bug nor adds a feature
-- [ ] performance: A code change that improves performance
-- [ ] test: Adding missing tests
-- [ ] chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
+- feature: A new feature
+- fix: A bug fix
+- documentation: Documentation only changes
+- style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)
+- refactor: A code change that neither fixes a bug nor adds a feature
+- performance: A code change that improves performance
+- test: Adding missing tests
+- chore: Changes to the build process or auxiliary tools and libraries such as documentation generation


### PR DESCRIPTION
# Description

Currently, when a PR is generated in ET, it uses the type of change below, but sets it to be a Task, which means people not deleting the options correctly show as a bunch of open tasks. This change moves it to a bullet point list, as it could be that some options need to be relevant so would be good as a list

## Type of change

- documentation: Documentation only changes
- style: Changes that do not affect the meaning of the code (white-space, formatting, missing semi-colons, etc)